### PR TITLE
add description to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "main": "index.js",
   "name": "json-pretty",
+  "description": "Simple module for producing nice JSON.",
   "repository": "https://github.com/michielbdejong/json-pretty",
   "version": "0.0.1"
 }


### PR DESCRIPTION
this info is exposed on yarnpkg.com, npmjs.com and others. If it's not filled in, the first part of the readme is used (which causes duplication)